### PR TITLE
Add cookie domain & CSRF initialization

### DIFF
--- a/app/backend/src/app.js
+++ b/app/backend/src/app.js
@@ -11,12 +11,27 @@ require('./config/passport'); // Passport config
 
 const authRoutes = require('./routes/auth');
 const accountRoutes = require('./routes/accounts');
+const accountRoutes = require('./routes/accounts');
 const transactionRoutes = require('./routes/transactions');
 const categoryRoutes = require('./routes/categories');
 const budgetRoutes = require('./routes/budgets');
 const userRoutes = require('./routes/user');
 const paymentRoutes = require('./routes/payments');
 const statusRoutes = require('./routes/status.routes');
+
+// Helper to get domain for cookies
+const getCookieDomain = () => {
+    if (process.env.NODE_ENV !== 'production') return undefined;
+    try {
+        const url = new URL(process.env.FRONTEND_URL);
+        // If frontend is https://budgettracko.bhargavkarande.dev
+        // We want .budgettracko.bhargavkarande.dev so both api (child) and frontend (parent) can share
+        return '.' + url.hostname;
+    } catch (e) {
+        console.error("Error parsing FRONTEND_URL for cookie domain:", e);
+        return undefined;
+    }
+};
 
 
 // Initialize app
@@ -118,8 +133,12 @@ app.use((req, res, next) => {
             res.cookie('csrf-token', csrfToken, {
                 httpOnly: false,         // Frontend JS must read this
                 secure: process.env.NODE_ENV === 'production',
-                sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
-                maxAge: 3 * 24 * 60 * 60 * 1000, // 3 days (same as auth cookie)
+                sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax', // Must be none for distinct subdomains if cross-site? Actually if subdomain, lax is fine usually, but none is safer for cross-origin if needed.
+                // However, for subdomains sharing cookies, 'Lax' is often enough IF base domain matches. 
+                // But let's stick to user's existing logic slightly modified.
+                // If we want cross-subdomain, we MUST set domain.
+                domain: getCookieDomain(),
+                maxAge: 3 * 24 * 60 * 60 * 1000,
                 path: '/',
             });
         }
@@ -155,6 +174,12 @@ app.use('/api/budgets', budgetRoutes);
 app.use('/api/payments', paymentRoutes);
 
 app.get('/api/health', (req, res) => res.status(200).json({ status: 'ok' })); // Simple health check
+// CSRF Token Endpoint - Explicitly fetch token
+app.get('/api/csrf-token', (req, res) => {
+    // The middleware above already sets the cookie if missing
+    // We just return it in JSON for convenience if needed, or just status ok
+    res.json({ csrfToken: req.cookies['csrf-token'] });
+});
 app.use('/api/status', statusRoutes);
 
 // Basic route

--- a/app/frontend/src/context/AuthContext.jsx
+++ b/app/frontend/src/context/AuthContext.jsx
@@ -28,7 +28,16 @@ export const AuthProvider = ({ children }) => {
     }, []);
 
     useEffect(() => {
-        fetchUser();
+        const initAuth = async () => {
+            try {
+                // Ensure CSRF token is set by making a GET request
+                await api.get('/api/csrf-token');
+            } catch (e) {
+                console.error("Failed to initialize CSRF token", e);
+            }
+            fetchUser();
+        };
+        initAuth();
     }, [fetchUser]);
 
     // Listen for 401 events from axios interceptor (auto-logout)


### PR DESCRIPTION
Derive and apply a cookie domain in production and add an explicit CSRF token endpoint; ensure frontend initializes the CSRF cookie before fetching user data. Backend: introduced getCookieDomain() (parses FRONTEND_URL in production and returns a dot-prefixed hostname), set domain on the csrf-token cookie, and added GET /api/csrf-token to return the cookie value. Frontend: AuthContext now requests /api/csrf-token on startup (before fetchUser) to ensure the CSRF cookie is present. This enables consistent CSRF cookie behavior for shared subdomains and improves auth initialization robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CSRF token API endpoint for retrieving tokens
  * Enabled cross-subdomain cookie support for CSRF tokens in production environments

* **Bug Fixes**
  * Improved authentication initialization flow with enhanced error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->