### PR TITLE
Add auth controller and frontend auth flows

### DIFF
--- a/app/backend/src/controllers/authController.js
+++ b/app/backend/src/controllers/authController.js
@@ -1,0 +1,115 @@
+const User = require('../models/User');
+const { generateToken, getCookieOptions } = require('../utils/authUtils');
+
+// Password validation regex: 8+ chars, 1 capital, 1 number, 1 symbol
+const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,}$/;
+// Strict email validation regex
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Blacklisted dummy email patterns
+const dummyKeywords = ['demo', 'test', 'example', 'dummy', 'guest'];
+
+/**
+ * @desc    Register a new user
+ * @route   POST /auth/signup
+ * @access  Public
+ */
+exports.signup = async (req, res) => {
+    try {
+        const { displayName, email, password } = req.body;
+
+        // Validation
+        if (!displayName || !email || !password) {
+            return res.status(400).json({ success: false, message: 'Please provide all required fields' });
+        }
+
+        if (!emailRegex.test(email)) {
+            return res.status(400).json({ success: false, message: 'Please provide a valid email address' });
+        }
+
+        // Check for dummy email patterns
+        const lowerEmail = email.toLowerCase();
+        const isDummy = dummyKeywords.some(keyword => lowerEmail.includes(keyword));
+        if (isDummy) {
+            return res.status(400).json({
+                success: false,
+                message: 'Dummy or demo email addresses are not allowed. Please use a real email address.'
+            });
+        }
+
+        if (!passwordRegex.test(password)) {
+            return res.status(400).json({
+                success: false,
+                message: 'Password must be at least 8 characters long and contain at least one uppercase letter, one number, and one symbol.'
+            });
+        }
+
+        // Check if user already exists
+        const exitingUser = await User.findOne({ email });
+        if (exitingUser) {
+            return res.status(400).json({ success: false, message: 'User already exists with this email' });
+        }
+
+        // Create user
+        const user = await User.create({
+            displayName,
+            email,
+            password
+        });
+
+        // Generate token and set cookie
+        const token = generateToken(user);
+        res.cookie('token', token, getCookieOptions());
+
+        res.status(201).json({
+            success: true,
+            message: 'User registered successfully',
+            data: {
+                id: user._id,
+                displayName: user.displayName,
+                email: user.email
+            }
+        });
+    } catch (err) {
+        console.error('Signup error:', err);
+        res.status(500).json({ success: false, message: 'Server error during registration' });
+    }
+};
+
+/**
+ * @desc    Authenticate user & get token
+ * @route   POST /auth/login
+ * @access  Public
+ */
+exports.login = async (req, res) => {
+    try {
+        const { email, password } = req.body;
+
+        if (!email || !password) {
+            return res.status(400).json({ success: false, message: 'Please provide email and password' });
+        }
+
+        // Find user by email and select password (since it's hidden by default in schema)
+        const user = await User.findOne({ email }).select('+password');
+
+        if (!user || !(await user.comparePassword(password))) {
+            return res.status(401).json({ success: false, message: 'Invalid credentials' });
+        }
+
+        // Generate token and set cookie
+        const token = generateToken(user);
+        res.cookie('token', token, getCookieOptions());
+
+        res.status(200).json({
+            success: true,
+            message: 'Logged in successfully',
+            data: {
+                id: user._id,
+                displayName: user.displayName,
+                email: user.email
+            }
+        });
+    } catch (err) {
+        console.error('Login error:', err);
+        res.status(500).json({ success: false, message: 'Server error during login' });
+    }
+};

--- a/app/backend/src/routes/auth.js
+++ b/app/backend/src/routes/auth.js
@@ -2,6 +2,11 @@ const express = require('express');
 const passport = require('passport');
 const router = express.Router();
 const { generateToken, getCookieOptions } = require('../utils/authUtils');
+const authController = require('../controllers/authController');
+
+// Local Auth
+router.post('/signup', authController.signup);
+router.post('/login', authController.login);
 
 // Google Auth
 router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));

--- a/app/frontend/src/pages/Login.jsx
+++ b/app/frontend/src/pages/Login.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 import { motion, AnimatePresence } from 'framer-motion';
 import { toast } from 'sonner';
 import { HiOutlineMail, HiOutlineLockClosed, HiOutlineEye, HiOutlineEyeOff } from 'react-icons/hi';
 import { FcGoogle } from 'react-icons/fc';
 import { FaGithub } from 'react-icons/fa';
 import { BsBarChartLineFill, BsWalletFill, BsShieldLockFill, BsArrowLeftShort, BsLightningChargeFill, BsPeopleFill, BsStarFill, BsCheckCircleFill } from 'react-icons/bs';
+import { authApi } from '../services/api';
 
 // Animation variants
 const staggerContainer = {
@@ -56,25 +58,42 @@ const testimonials = [
 
 const Login = () => {
     const navigate = useNavigate();
+    const { login } = useAuth();
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
     const [focusedField, setFocusedField] = useState(null);
+    const [formData, setFormData] = useState({
+        email: '',
+        password: ''
+    });
+
+    const handleChange = (e) => {
+        setFormData({ ...formData, [e.target.id]: e.target.value });
+    };
 
     // Get redirect path from URL query params
     const searchParams = new URLSearchParams(window.location.search);
     const redirectPath = searchParams.get('redirect') || '/dashboard';
 
-    const handleLogin = (e) => {
+    const handleLogin = async (e) => {
         e.preventDefault();
         setLoading(true);
         toast.loading('Signing you in...', { id: 'login' });
-        setTimeout(() => {
+
+        try {
+            const response = await authApi.login(formData);
+            if (response.data.success) {
+                await login(); // Refresh user state in AuthContext
+                toast.success('Welcome back! Redirecting to dashboard...', { id: 'login' });
+                navigate(redirectPath);
+            }
+        } catch (error) {
+            console.error('Login error:', error);
+            const message = error.response?.data?.message || 'Invalid email or password';
+            toast.error(message, { id: 'login' });
+        } finally {
             setLoading(false);
-            toast.success('Welcome back! Redirecting to dashboard...', { id: 'login' });
-            setLoading(false);
-            toast.success('Welcome back!', { id: 'login' });
-            navigate(redirectPath);
-        }, 1500);
+        }
     };
 
     return (
@@ -333,6 +352,8 @@ const Login = () => {
                                                 type="email"
                                                 placeholder="username@gmail.com"
                                                 required
+                                                value={formData.email}
+                                                onChange={handleChange}
                                                 onFocus={() => setFocusedField('email')}
                                                 onBlur={() => setFocusedField(null)}
                                                 className="w-full pl-10 pr-4 py-3 rounded-xl border-2 border-black/80 bg-gray-50 focus:bg-white focus:border-black focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-1 text-brand-black placeholder-gray-400 font-medium text-sm transition-all"
@@ -361,6 +382,8 @@ const Login = () => {
                                                 type={showPassword ? 'text' : 'password'}
                                                 placeholder="Enter password"
                                                 required
+                                                value={formData.password}
+                                                onChange={handleChange}
                                                 onFocus={() => setFocusedField('password')}
                                                 onBlur={() => setFocusedField(null)}
                                                 className="w-full pl-10 pr-11 py-3 rounded-xl border-2 border-black/80 bg-gray-50 focus:bg-white focus:border-black focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-1 text-brand-black placeholder-gray-400 font-medium text-sm transition-all"

--- a/app/frontend/src/pages/Signup.jsx
+++ b/app/frontend/src/pages/Signup.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 import { motion, AnimatePresence } from 'framer-motion';
 import { toast } from 'sonner';
 import { HiOutlineMail, HiOutlineLockClosed, HiOutlineEye, HiOutlineEyeOff, HiOutlineUser } from 'react-icons/hi';
 import { FcGoogle } from 'react-icons/fc';
 import { FaGithub } from 'react-icons/fa';
 import { BsBarChartLineFill, BsWalletFill, BsShieldLockFill, BsArrowLeftShort, BsLightningChargeFill, BsPeopleFill, BsStarFill, BsCheckCircleFill, BsArrowRight } from 'react-icons/bs';
+import { authApi } from '../services/api';
 
 // Animation variants
 const staggerContainer = {
@@ -51,19 +53,62 @@ const steps = [
 
 const Signup = () => {
     const navigate = useNavigate();
+    const { login } = useAuth();
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
     const [focusedField, setFocusedField] = useState(null);
+    const [formData, setFormData] = useState({
+        displayName: '',
+        email: '',
+        password: ''
+    });
 
-    const handleSignup = (e) => {
+    const handleChange = (e) => {
+        setFormData({ ...formData, [e.target.id]: e.target.value });
+    };
+
+    const validatePassword = (password) => {
+        const hasUpper = /[A-Z]/.test(password);
+        const hasNumber = /[0-9]/.test(password);
+        const hasSymbol = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+        const hasMinLen = password.length >= 8;
+        return { hasUpper, hasNumber, hasSymbol, hasMinLen, isValid: hasUpper && hasNumber && hasSymbol && hasMinLen };
+    };
+
+    const handleSignup = async (e) => {
         e.preventDefault();
+
+        const dummyKeywords = ['demo', 'test', 'example', 'dummy', 'guest'];
+        const isDummy = dummyKeywords.some(keyword => formData.email.toLowerCase().includes(keyword));
+
+        if (isDummy) {
+            toast.error('Dummy or demo email addresses are not allowed. Please use a real email address.');
+            return;
+        }
+
+        const validation = validatePassword(formData.password);
+        if (!validation.isValid) {
+            toast.error('Password must be at least 8 characters long and contain at least one uppercase letter, one number, and one symbol.');
+            return;
+        }
+
         setLoading(true);
         toast.loading('Creating your account...', { id: 'signup' });
-        setTimeout(() => {
+
+        try {
+            const response = await authApi.signup(formData);
+            if (response.data.success) {
+                await login(); // Refresh user state in AuthContext
+                toast.success('Account created! Welcome to BudgetTracko!', { id: 'signup' });
+                navigate('/dashboard');
+            }
+        } catch (error) {
+            console.error('Signup error:', error);
+            const message = error.response?.data?.message || 'Failed to create account. Please try again.';
+            toast.error(message, { id: 'signup' });
+        } finally {
             setLoading(false);
-            toast.success('Account created! Welcome to BudgetTracko!', { id: 'signup' });
-            navigate('/dashboard');
-        }, 1500);
+        }
     };
 
     return (
@@ -331,11 +376,13 @@ const Signup = () => {
                                         >
                                             <HiOutlineUser className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-brand-black/35 pointer-events-none" aria-hidden />
                                             <input
-                                                id="fullname"
+                                                id="displayName"
                                                 type="text"
                                                 placeholder="Bhargav Karande"
                                                 required
-                                                onFocus={() => setFocusedField('fullname')}
+                                                value={formData.displayName}
+                                                onChange={handleChange}
+                                                onFocus={() => setFocusedField('displayName')}
                                                 onBlur={() => setFocusedField(null)}
                                                 className="w-full pl-10 pr-4 py-3 rounded-xl border-2 border-black/80 bg-gray-50 focus:bg-white focus:border-black focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-1 text-brand-black placeholder-gray-400 font-medium text-sm transition-all"
                                             />
@@ -358,6 +405,8 @@ const Signup = () => {
                                                 type="email"
                                                 placeholder="you@college.edu"
                                                 required
+                                                value={formData.email}
+                                                onChange={handleChange}
                                                 onFocus={() => setFocusedField('email')}
                                                 onBlur={() => setFocusedField(null)}
                                                 className="w-full pl-10 pr-4 py-3 rounded-xl border-2 border-black/80 bg-gray-50 focus:bg-white focus:border-black focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-1 text-brand-black placeholder-gray-400 font-medium text-sm transition-all"
@@ -382,6 +431,8 @@ const Signup = () => {
                                                 placeholder="Min. 8 characters"
                                                 required
                                                 minLength={8}
+                                                value={formData.password}
+                                                onChange={handleChange}
                                                 onFocus={() => setFocusedField('password')}
                                                 onBlur={() => setFocusedField(null)}
                                                 className="w-full pl-10 pr-11 py-3 rounded-xl border-2 border-black/80 bg-gray-50 focus:bg-white focus:border-black focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-1 text-brand-black placeholder-gray-400 font-medium text-sm transition-all"

--- a/app/frontend/src/services/api.js
+++ b/app/frontend/src/services/api.js
@@ -44,6 +44,14 @@ api.interceptors.response.use(
     }
 );
 
+// ─── Authentication ───
+export const authApi = {
+    signup: (data) => api.post('/auth/signup', data),
+    login: (data) => api.post('/auth/login', data),
+    logout: () => api.get('/auth/logout'),
+    getMe: () => api.get('/auth/me')
+};
+
 // ─── Transactions ───
 export const transactionApi = {
     getAll: (params) => api.get('/api/transactions', { params }),


### PR DESCRIPTION
Add server-side authController with signup/login handlers, email/password validation, dummy-email checks, token generation and cookie setting. Wire routes to use the new controller. Update frontend Signup and Login pages to use authApi, add local form state, client-side password/email validation, remove artificial timeouts and perform real async signup/login calls, and refresh AuthContext on success. Also add authApi endpoints to services/api for signup, login, logout and getMe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local authentication: Users can sign up and log in using email and password credentials
  * Password strength requirements: minimum 8 characters, one uppercase letter, one number, and one special character
  * Enhanced form validation to prevent dummy emails and duplicate account registrations
  * Secure session management with token issuance and cookie-based authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->