### PR TITLE
Add web manifest and app icons for PWA

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/logo192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/logo512.png" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no" />
     <title>BudgetTracko - Smart Expense Manager</title>
     <script src="https://checkout.razorpay.com/v1/checkout.js"></script>

--- a/app/frontend/public/manifest.json
+++ b/app/frontend/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "short_name": "BudgetTracko",
+  "name": "BudgetTracko - Expense Manager",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "logo192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "logo512.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}


### PR DESCRIPTION
Add a manifest.json with app metadata and icons (favicon, logo192, logo512) and update index.html to include icon links (png icons and apple-touch-icon) and a manifest link. These changes enable basic PWA support and provide proper app icons for install/home-screen on mobile devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Progressive Web App (PWA) support, enabling users to install BudgetTracko as a standalone application on their devices with custom icons and branding for improved accessibility and engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->