### PR TITLE
Add confirmation modal for maintenance toggle

### DIFF
--- a/app/frontend/src/pages/admin/AdminSettings.jsx
+++ b/app/frontend/src/pages/admin/AdminSettings.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { adminApi } from '../../services/adminApi';
 import { useTheme } from '../../context/ThemeContext';
 import { toast } from 'sonner';
+import ConfirmationModal from '../../components/common/ConfirmationModal';
 
 const AdminSettings = () => {
     const { theme, toggleTheme } = useTheme();
@@ -18,6 +19,13 @@ const AdminSettings = () => {
     const [saving, setSaving] = useState(false);
     const [savingMaintenance, setSavingMaintenance] = useState(false);
     const [savingAnnouncement, setSavingAnnouncement] = useState(false);
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
+    const [confirmModalConfig, setConfirmModalConfig] = useState({
+        title: '',
+        message: '',
+        onConfirm: () => { },
+        type: 'info'
+    });
 
     useEffect(() => {
         const fetchConfig = async () => {
@@ -146,9 +154,16 @@ const AdminSettings = () => {
                         whileTap={{ scale: 0.95 }}
                         onClick={() => {
                             if (!maintenanceMode) {
-                                if (window.confirm('Are you sure you want to enable Maintenance Mode? This will block all non-admin users from accessing the application.')) {
-                                    handleToggleMaintenance();
-                                }
+                                setConfirmModalConfig({
+                                    title: 'Enable Maintenance Mode?',
+                                    message: 'This will block all non-admin users from accessing the application until disabled. Are you sure?',
+                                    onConfirm: () => {
+                                        handleToggleMaintenance();
+                                        setShowConfirmModal(false);
+                                    },
+                                    type: 'warning'
+                                });
+                                setShowConfirmModal(true);
                             } else {
                                 handleToggleMaintenance();
                             }
@@ -427,6 +442,16 @@ const AdminSettings = () => {
                     </a>
                 </div>
             </motion.div>
+
+            {/* Confirmation Modal */}
+            <ConfirmationModal
+                isOpen={showConfirmModal}
+                onClose={() => setShowConfirmModal(false)}
+                onConfirm={confirmModalConfig.onConfirm}
+                title={confirmModalConfig.title}
+                message={confirmModalConfig.message}
+                type={confirmModalConfig.type}
+            />
         </div>
     );
 };


### PR DESCRIPTION
Replace the synchronous window.confirm prompt with a reusable ConfirmationModal when enabling Maintenance Mode. Imported the modal component, added showConfirmModal and confirmModalConfig state to hold modal content and callback, updated the maintenance toggle click handler to open the modal with a warning message and onConfirm invoking handleToggleMaintenance, and rendered the ConfirmationModal with appropriate props.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance Mode enablement now requires confirmation through an integrated modal dialog instead of a browser confirmation prompt, providing a seamless user experience within admin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->